### PR TITLE
Add `parserOptions` for configuring Babel parsing

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -16,10 +16,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function transformTaggedContent(content, options = {}) {
   const {
+    parserOptions = {},
     tagsToProcess = [],
     transformer = code => code
   } = options;
-  const ast = (0, _parser.parse)(content);
+  const ast = (0, _parser.parse)(content, parserOptions);
   (0, _traverse.default)(ast, {
     TaggedTemplateExpression(path) {
       if (tagsToProcess.includes(path.node.tag.name)) {

--- a/esm/index.js
+++ b/esm/index.js
@@ -4,11 +4,12 @@ import generate from '@babel/generator';
 
 export function transformTaggedContent(content, options = {}) {
 	const {
+		parserOptions = {},
 		tagsToProcess = [],
 		transformer = code => code
 	} = options;
 
-	const ast = parse(content);
+	const ast = parse(content, parserOptions);
 
 	traverse(ast, {
 		TaggedTemplateExpression(path) {

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,34 @@ const result = handleCSS`
 ]
 ```
 
+### `parserOptions: object`
+
+Config options to pass to the Babel parser.
+
+> Babel Parser options may be needed depending on how your project is structured. See [Babel parser options](https://babeljs.io/docs/en/babel-parser#options) for all available options.
+
+Example:
+
+```js
+// rollup.js
+	// ...
+	plugins: [
+		transformTaggedTemplate({
+			parserOptions: {
+				sourceType: "module", // treat files as ES6 modules
+				plugins: [
+					"typescript", // parse the file as TypeScript
+					[
+						"decorators", // use decorators proposal plugin
+						{ decoratorsBeforeExport: true }
+					]
+				]
+			}
+		})
+	],
+	// ...
+```
+
 ## Related
 
 - [rollup-plugin-minify-tagged-css-template](https://github.com/notlmn/rollup-plugin-minify-tagged-css-template) - Rollup plugin to minify CSS content of tagged template string literals.


### PR DESCRIPTION
Adds a `parserOptions` config value that allows for Babel parser options to be set.

Closes #1 